### PR TITLE
feat: notify PR submitter with random congrats message on successful deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  pull-requests: write
 
 # Allow one concurrent deployment; cancel in-progress runs on new push
 concurrency:
@@ -52,3 +53,49 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Congratulate PR author
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+
+            if (prs.length === 0) {
+              console.log('No associated PR found — skipping notification.');
+              return;
+            }
+
+            const pr = prs[0];
+            const author = pr.user.login;
+
+            const messages = [
+              "🚀 Your changes just went live! The internet is a slightly better place thanks to you. Keep shipping!",
+              "🎉 Boom — deployed! Your contribution is now out in the wild. The open-source community thanks you!",
+              "✨ Another PR merged, another ripple in the open-source ocean. Beautifully done — your work is live!",
+              "🌍 Your diff is now reality. This is what open source is all about — thank you for making it happen!",
+              "🛸 Successfully deployed to production! You just made the codebase a little more awesome. Well played!",
+              "🔥 Your PR is live and thriving! This is the way — keep building, keep sharing, keep being amazing!",
+              "🌟 Contribution received, reviewed, merged, and deployed. You nailed every step. The project is better for it!",
+              "🏄 Riding the merge wave all the way to production! Your work is now live — go ahead and take a victory lap!",
+              "💡 Great ideas deserve to ship — and yours just did. Welcome to the 'my code is in production' club!",
+              "🎸 That PR? Absolute banger. It's live now. Open source wouldn't be the same without contributors like you!",
+            ];
+
+            const message = messages[Math.floor(Math.random() * messages.length)];
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: `@${author} ${message}`,
+            });
+
+            console.log(`Notified @${author} on PR #${pr.number}.`);


### PR DESCRIPTION
## Why

Contributors don't get any feedback after their PR is merged and deployed to GitHub Pages. Adding a personal touch -- tagging the submitter with a congratulatory message -- reinforces open-source community values and lets contributors know their work made it all the way to production.

## What changed

A new `notify` job has been added to the `gh-pages.yml` workflow. It runs only after a successful `deploy`, finds the PR associated with the merge commit, and posts a comment on that PR @-mentioning the author with a randomly selected congratulation message.

Key details:
- Added `pull-requests: write` permission to the workflow (required to post comments)
- `notify` job uses `actions/github-script` to call the GitHub REST API -- no extra secrets or third-party actions needed
- Messages are drawn from a pool of 10 open-source-flavoured, emoji-rich congratulations strings, picked at random each run
- If the triggering push is not associated with a PR (e.g. a direct push), the job skips gracefully with a log message